### PR TITLE
Add module exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,24 @@
-<div align="center">
+<div>
 	<br>
 	<br>
-	<img width="150" src="docs/media/slyk.png" alt="Slyk">
+	<p align="center"><a href="https://slyk.io/"><img width="150" src="docs/media/slyk.png" alt="Slyk"></a></p>
 	<br>
-	<br>
-	<p align="center"><img width="50" src="docs/media/logo.png" alt="Slyk"> - Node.js SDK </p>
+	<p align="center"><a href="https://slyk.io/"><img width="50" src="docs/media/logo.png" alt="Slyk"></a> - Node.js SDK </p>
 	<br>
 	<br>
 </div>
+
+![Travis (.org)](https://img.shields.io/travis/slykio/slyk-sdk-node)
+[![Coverage Status](https://coveralls.io/repos/github/slykio/slyk-sdk-node/badge.svg?branch=master)](https://coveralls.io/github/slykio/slyk-sdk-node?branch=master)
 
 ## Table of contents
 - [Install](#install)
 - [Usage](#usage)
 - [Available methods](docs/methods.md)
+
+This library allows you to quickly integrate **Slyk** with your Node.js application.
+
+For additional information and documentation please visit our [developers page](https://developers.slyk.io).
 
 ## Install
 
@@ -20,12 +26,12 @@
 $ yarn add @slyk/slyk-sdk-node
 ```
 
-> The `slyk-sdk-node` requires node **v8.6.0** or higher.
+The `slyk-sdk-node` requires node **v8.6.0** or higher.
 
 ## Usage
 
 ```js
-const slykSDK = require('slyk-sdk-node');
+const slykSDK = require('@slyk/slyk-sdk-node');
 
 (async () => {
   const slyk = slykSDK({ apikey: 'foobar' });

--- a/babel.config.js
+++ b/babel.config.js
@@ -5,6 +5,7 @@
 
 module.exports = {
   plugins: [
+    ['add-module-exports'],
     ['module-resolver', {
       alias: {
         test: './test'

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@babel/plugin-proposal-class-properties": "^7.3.4",
     "@babel/preset-env": "^7.3.4",
     "babel-core": "^7.0.0-bridge.0",
+    "babel-plugin-add-module-exports": "^1.0.2",
     "babel-plugin-module-resolver": "^3.2.0",
     "eslint": "^5.15.1",
     "eslint-config-seegno": "15.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,6 +1312,13 @@ babel-jest@^24.9.0:
     chalk "^2.4.2"
     slash "^2.0.0"
 
+babel-plugin-add-module-exports@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.2.tgz#96cd610d089af664f016467fc4567c099cce2d9c"
+  integrity sha512-4paN7RivvU3Rzju1vGSHWPjO8Y0rI6droWvSFKI6dvEQ4mvoV0zGojnlzVRfI6N8zISo6VERXt3coIuVmzuvNg==
+  optionalDependencies:
+    chokidar "^2.0.4"
+
 babel-plugin-istanbul@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz#df4ade83d897a92df069c4d9a25cf2671293c854"
@@ -1560,6 +1567,25 @@ chokidar@^2.0.3:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.4.tgz#244a65d68beedf1078c2f193cf2735c2cfdc7da2"
   integrity sha512-ZVuFiB9IGOHqu+Jh7B7fSTmzsfDmUtC6yqd/V72UPQeXbNHONbMV0chOXtLXjsP3NvdUsHTNMg02NtXPDaSmNQ==
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.1"
+    braces "^2.3.2"
+    glob-parent "^3.1.0"
+    inherits "^2.0.3"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    normalize-path "^3.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.2.1"
+    upath "^1.1.1"
+  optionalDependencies:
+    fsevents "^1.2.7"
+
+chokidar@^2.0.4:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
+  integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
   dependencies:
     anymatch "^2.0.0"
     async-each "^1.0.1"


### PR DESCRIPTION
This PR adds the `babel-plugin-add-module-exports` dev dependency in order to include the `module.exports` line when building the `sdk`.

This PR also adds some new badges the `README` file. 