### PR TITLE
Fix ResolverFactory URL query string encoding

### DIFF
--- a/src/core/resolvers/api-url-resolver.js
+++ b/src/core/resolvers/api-url-resolver.js
@@ -6,7 +6,6 @@
 import { InternalServerError } from 'easy-http-errors';
 import { isEmpty, isString, map, reduce, replace } from 'lodash';
 import normalize from 'normalize-url';
-import qs from 'qs';
 
 /**
  * Export `apiUrlResolver`.
@@ -15,8 +14,7 @@ import qs from 'qs';
 export default ({
   data,
   endpoint,
-  host,
-  options
+  host
 }) => {
   if (!host) {
     throw new InternalServerError('API host is not defined');
@@ -38,9 +36,8 @@ export default ({
     throw new InternalServerError('Missing parameters', { missingParams });
   }
 
-  const params = qs.stringify(options);
   const baseUrl = host.replace(/^(?!(?:\w+:)?\/\/)/, 'https://');
-  const url = baseUrl.concat(`/${path}`).concat(`?${params}`);
+  const url = baseUrl.concat(`/${path}`);
 
   return normalize(url);
 };

--- a/src/core/util/resolver-factory.js
+++ b/src/core/util/resolver-factory.js
@@ -8,6 +8,7 @@ import apiUrlResolver from 'core/resolvers/api-url-resolver';
 import cleanRequestData from 'core/util/clean-request-data';
 import errorHandler from 'core/util/error-handler';
 import got from 'got';
+import qs from 'qs';
 import sortMiddleware from 'core/middlewares/sort-middleware';
 
 /**
@@ -34,7 +35,8 @@ const createTask = (connection, task) => {
         body: requestData,
         headers: { apikey },
         json: true,
-        method
+        method,
+        query: qs.stringify(options)
       });
 
       return body;


### PR DESCRIPTION
At this moment, the URL query string parameters encoded in ApiUrlResolver are being decoded right after because of the usage of `normalize-url` function. So, this commit removes the query string parameters from the URL string and adds it to the `query` property of `got` request options.