### PR TITLE
Fix errorHandler by handling incoming data object

### DIFF
--- a/src/core/util/error-handler.js
+++ b/src/core/util/error-handler.js
@@ -12,8 +12,13 @@ import httpErrorResolver from 'core/resolvers/http-error-resolver';
 
 export default error => {
   const { statusCode } = error;
-  const { code: message, errors } = get(error, 'response.body', {});
+  const {
+    code: message,
+    data,
+    errors
+  } = get(error, 'response.body', {});
+
   const HTTPError = httpErrorResolver(statusCode);
 
-  throw new HTTPError({ errors, message });
+  throw new HTTPError(message, { data, errors });
 };

--- a/test/src/address/managers/address-manager.test.js
+++ b/test/src/address/managers/address-manager.test.js
@@ -43,7 +43,11 @@ describe('AddressManager', () => {
     it('should throw `NotFoundError` if the given `address` does not exist', async () => {
       nock(host, { reqheaders: { apikey } })
         .get('/addresses/foobar')
-        .reply(404, { code: 'address_not_found' });
+        .reply(404, {
+          code: 'address_not_found',
+          data: { foo: 'bar' },
+          errors: [{ waldo: 'fred' }]
+        });
 
       try {
         await slyk.address.get('foobar');
@@ -51,6 +55,8 @@ describe('AddressManager', () => {
         fail();
       } catch (error) {
         expect(error).toBeInstanceOf(NotFoundError);
+        expect(error.data).toEqual({ foo: 'bar' });
+        expect(error.errors).toEqual([{ waldo: 'fred' }]);
         expect(error.message).toEqual('address_not_found');
       }
     });


### PR DESCRIPTION
This PR fixes `errorHandler` by destructuring the incoming `data` object and by providing both `data` and `errors` as the `HttpError` constructor second argument.