### PR TITLE
Add delete to user module

### DIFF
--- a/docs/methods.md
+++ b/docs/methods.md
@@ -4086,6 +4086,24 @@ await slyk.user.get('5e101529-fa30-4415-9945-6540e70c4483');
 }
 ```
 
+### `user.delete`
+
+Deletes the `user` of the given `id`.
+
+**Example:**
+
+#### Request
+
+```js
+await slyk.user.delete('5e101529-fa30-4415-9945-6540e70c4483');
+```
+
+#### Response
+
+```json
+true
+```
+
 ### `user.list`
 
 Retrieves a list of `user`.

--- a/src/user/managers/user-manager.js
+++ b/src/user/managers/user-manager.js
@@ -121,6 +121,16 @@ export default class UserManager extends AbstractManager {
   }
 
   /**
+   * Delete.
+   */
+
+  async delete(id) {
+    await this._resolver.delete({ id });
+
+    return true;
+  }
+
+  /**
    * List.
    */
 

--- a/src/user/models/user-model.js
+++ b/src/user/models/user-model.js
@@ -53,6 +53,14 @@ export default class UserModel extends AbstractModel {
   }
 
   /**
+   * Delete.
+   */
+
+  delete() {
+    return this._sdk.user.delete(this.id);
+  }
+
+  /**
    * Get invites.
    */
 

--- a/src/user/resolvers/user-resolver.js
+++ b/src/user/resolvers/user-resolver.js
@@ -42,6 +42,10 @@ const config = {
     endpoint: 'users',
     method: 'post'
   },
+  delete: {
+    endpoint: 'users/:id',
+    method: 'delete'
+  },
   forgotPassword: {
     endpoint: 'users/forgot-password',
     method: 'post'

--- a/test/src/user/managers/user-manager.test.js
+++ b/test/src/user/managers/user-manager.test.js
@@ -142,6 +142,18 @@ describe('UserManager', () => {
     });
   });
 
+  describe('delete', () => {
+    it('should call api `/users/bar` endpoint with method `delete` and return `true`', async () => {
+      nock(host, { reqheaders: { apikey } })
+        .delete('/users/bar')
+        .reply(204);
+
+      const result = await slyk.user.delete('bar');
+
+      expect(result).toEqual(true);
+    });
+  });
+
   describe('forgotPassword', () => {
     it('should call api `/users/forgot-password` endpoint with method `post` and return the created reset password token', async () => {
       nock(host, { reqheaders: { apikey } })

--- a/test/src/user/models/user-model.test.js
+++ b/test/src/user/models/user-model.test.js
@@ -135,6 +135,26 @@ describe('UserModel', () => {
     });
   });
 
+  describe('delete', () => {
+    it('should return `true` after deleting the `user` instance', async () => {
+      nock(host, { reqheaders: { apikey } })
+        .get('/users/bar')
+        .reply(200, {
+          data: { email: 'foo@bar.com', id: 'bar' }
+        });
+
+      const user = await slyk.user.get('bar');
+
+      nock(host, { reqheaders: { apikey } })
+        .delete('/users/bar')
+        .reply(204);
+
+      const result = await user.delete();
+
+      expect(result).toEqual(true);
+    });
+  });
+
   describe('getInvites', () => {
     it('should return a list of `invites` that belong to `user` instance', async () => {
       nock(host, { reqheaders: { apikey } })


### PR DESCRIPTION
This PR adds the `delete` method to `UserManager` and `UserModel` to delete the `user` of the given `id`.