### PR TITLE
Add Webhook module methods

### DIFF
--- a/docs/methods.md
+++ b/docs/methods.md
@@ -422,6 +422,22 @@
     - [`wallet.transactions`](#wallettransactions)
       - [Request](#request-130)
       - [Response](#response-128)
+  - [webhook](#webhook)
+    - [`webhook.create`](#webhookcreate)
+      - [Request](#request-131)
+      - [Response](#response-129)
+    - [`webhook.delete`](#webhookdelete)
+      - [Request](#request-132)
+      - [Response](#response-130)
+    - [`webhook.get`](#webhookget)
+      - [Request](#request-133)
+      - [Response](#response-131)
+    - [`webhook.list`](#webhooklist)
+      - [Request](#request-134)
+      - [Response](#response-132)
+    - [`webhook.patch`](#webhookpatch)
+      - [Request](#request-135)
+      - [Response](#response-133)
 
 ## address
 
@@ -5579,5 +5595,147 @@ await slyk.wallet.transactions('4b1a22bf-642c-4c4f-bfb4-678e59121e74';
     "updatedAt": "2019-03-20T14:30:37.483Z"
   }],
   "total": 2
+}
+```
+
+## webhook
+
+The result of each one of the following `webhook` methods return one or an array of `Webhook` objects that include the following methods:
+- `delete`: Deletes the `webhook`.
+- `patch`: Patches the `webhook`.
+
+### `webhook.create`
+
+Subscribes a list of `webhook` events.
+
+**Example:**
+
+#### Request
+
+```js
+await slyk.webhook.create({
+  description: 'waldo',
+  enabled: true,
+  events: ['transaction.deposit.confirmed'],
+  url: 'https://foo.bar/qux'
+});
+```
+
+#### Response
+
+```json
+{
+  "createdAt": "2021-04-29T12:00:00.000Z",
+  "description": "waldo",
+  "enabled": true,
+  "id": "25d81706-b15f-49a5-a4e3-c301cb3dc50a",
+  "events": ["transaction.deposit.confirmed"],
+  "url": "https://foo.bar/qux"
+}
+```
+
+### `webhook.delete`
+
+Deletes the `webhook` of the given `id`.
+
+**Example:**
+
+#### Request
+
+```js
+await slyk.webhook.delete('4b1a22bf-642c-4c4f-bfb4-678e59121e74');
+```
+
+#### Response
+
+```json
+true
+```
+
+### `webhook.get`
+
+Returns the `webhook` of the given `id`.
+
+**Example:**
+
+#### Request
+
+```js
+await slyk.webhook.get('4b1a22bf-642c-4c4f-bfb4-678e59121e74');
+```
+
+#### Response
+
+```json
+{
+  "createdAt": "2021-04-29T12:00:00.000Z",
+  "description": "waldo",
+  "enabled": true,
+  "id": "4b1a22bf-642c-4c4f-bfb4-678e59121e74",
+  "events": ["transaction.deposit.confirmed"],
+  "url": "https://foo.bar/qux"
+}
+```
+
+### `webhook.list`
+
+Returns a list of `webhook`.
+
+**Example:**
+
+#### Request
+
+```js
+await slyk.webhook.list({ filter: { enabled: true } });
+```
+
+#### Response
+
+```json
+{
+  "results": [
+    {
+      "createdAt": "2021-04-29T12:00:00.000Z",
+      "description": "waldo",
+      "enabled": true,
+      "id": "4b1a22bf-642c-4c4f-bfb4-678e59121e74",
+      "events": ["transaction.deposit.confirmed"],
+      "url": "https://foo.bar/qux"
+    },
+    {
+      "createdAt": "2021-04-29T12:00:00.000Z",
+      "description": "fred",
+      "enabled": true,
+      "id": "331a22bf-642c-4c4f-bfb4-678e59121ebb",
+      "events": ["transaction.deposit.created"],
+      "url": "https://foo.bar/thud"
+    }
+  ],
+  "total": 2
+}
+```
+
+### `webhook.patch`
+
+Patches the `webhook` of the given `id`.
+
+**Example:**
+
+#### Request
+
+```js
+await slyk.webhook.patch('4b1a22bf-642c-4c4f-bfb4-678e59121e74', { enabled: false });
+```
+
+#### Response
+
+```json
+{
+  "createdAt": "2021-04-29T12:00:00.000Z",
+  "description": "waldo",
+  "enabled": false,
+  "id": "4b1a22bf-642c-4c4f-bfb4-678e59121e74",
+  "events": ["transaction.deposit.confirmed"],
+  "url": "https://foo.bar/qux"
 }
 ```

--- a/src/core/library/index.js
+++ b/src/core/library/index.js
@@ -32,6 +32,7 @@ import setting from 'setting';
 import transaction from 'transaction';
 import user from 'user';
 import wallet from 'wallet';
+import webhook from 'webhook';
 
 /**
  * Export `library`.
@@ -63,5 +64,6 @@ export default {
   taxRate,
   transaction,
   user,
-  wallet
+  wallet,
+  webhook
 };

--- a/src/webhook/index.js
+++ b/src/webhook/index.js
@@ -1,0 +1,20 @@
+
+/* istanbul ignore file */
+
+/**
+ * Module dependencies.
+ */
+
+import WebhookManager from 'webhook/managers/webhook-manager';
+import WebhookModel from 'webhook/models/webhook-model';
+import WebhookResolver from 'webhook/resolvers/webhook-resolver';
+
+/**
+ * Export `webhook`.
+ */
+
+export default {
+  manager: WebhookManager,
+  model: WebhookModel,
+  resolver: WebhookResolver
+};

--- a/src/webhook/managers/webhook-manager.js
+++ b/src/webhook/managers/webhook-manager.js
@@ -1,0 +1,67 @@
+
+/**
+ * Module dependencies.
+ */
+
+import { get, map, merge } from 'lodash';
+import AbstractManager from 'core/managers/abstract-manager';
+
+/**
+ * Export `WebhookManager`.
+ */
+
+export default class WebhookManager extends AbstractManager {
+
+  /**
+   * Create.
+   */
+
+  async create(data) {
+    const { data: webhook } = await this.resolver.create(data);
+
+    return this.instantiate(webhook);
+  }
+
+  /**
+   * Delete.
+   */
+
+  async delete(id) {
+    await this.resolver.delete({ id });
+
+    return true;
+  }
+
+  /**
+   * Get.
+   */
+
+  async get(id, options) {
+    const { data: webhook } = await this.resolver.get({ id }, options);
+
+    return this.instantiate(webhook);
+  }
+
+  /**
+   * List.
+   */
+
+  async list(options) {
+    const result = await this.resolver.list({}, options);
+    const results = map(get(result, 'data', []), webhook => this.instantiate(webhook));
+    const total = get(result, 'total');
+
+    return { results, total };
+  }
+
+  /**
+   * Patch.
+   */
+
+  async patch(id, data) {
+    const { data: webhook } = await this.resolver.patch(merge({}, data, { id }));
+
+    return this.instantiate(webhook);
+  }
+
+}

--- a/src/webhook/models/webhook-model.js
+++ b/src/webhook/models/webhook-model.js
@@ -1,0 +1,30 @@
+
+/**
+ * Module dependencies.
+ */
+
+import AbstractModel from 'core/models/abstract-model';
+
+/**
+ * Export `WebhookModel`.
+ */
+
+export default class WebhookModel extends AbstractModel {
+
+  /**
+   * Delete.
+   */
+
+  delete() {
+    return WebhookModel.sdk.webhook.delete(this.id);
+  }
+
+  /**
+   * Patch.
+   */
+
+  patch(data) {
+    return WebhookModel.sdk.webhook.patch(this.id, data);
+  }
+
+}

--- a/src/webhook/resolvers/webhook-resolver.js
+++ b/src/webhook/resolvers/webhook-resolver.js
@@ -1,0 +1,39 @@
+
+/**
+ * Module dependencies.
+ */
+
+import resolverFactory from 'core/util/resolver-factory';
+
+/**
+ * Configuration.
+ */
+
+const config = {
+  create: {
+    endpoint: 'webhooks',
+    method: 'post'
+  },
+  delete: {
+    endpoint: 'webhooks/:id',
+    method: 'delete'
+  },
+  get: {
+    endpoint: 'webhooks/:id',
+    method: 'get'
+  },
+  list: {
+    endpoint: 'webhooks',
+    method: 'get'
+  },
+  patch: {
+    endpoint: 'webhooks/:id',
+    method: 'patch'
+  }
+};
+
+/**
+ * Export `WebhookResolver`.
+ */
+
+export default connection => resolverFactory(connection, config);

--- a/test/src/webhook/managers/webhook-manager.test.js
+++ b/test/src/webhook/managers/webhook-manager.test.js
@@ -1,0 +1,100 @@
+
+/**
+ * Module dependencies.
+ */
+
+import nock from 'nock';
+import sdk from '';
+
+/**
+ * Test `WebhookManager`.
+ */
+
+describe('WebhookManager', () => {
+  const apikey = 'xyzzy';
+  const host = 'http://foobar:3000';
+  const slyk = sdk({ apikey, host });
+
+  describe('create', () => {
+    it('should call api `/webhooks` endpoint with method `post` and return an instance of `Webhook` model with the given `data`', async () => {
+      nock(host, { reqheaders: { apikey } })
+        .post('/webhooks')
+        .reply(200, { data: { description: 'bar', enabled: true } });
+
+      const result = await slyk.webhook.create();
+
+      expect(result).toEqual({ description: 'bar', enabled: true });
+    });
+  });
+
+  describe('delete', () => {
+    it('should call api `/webhooks/bar` endpoint with method `delete` and return `true`', async () => {
+      nock(host, { reqheaders: { apikey } })
+        .delete('/webhooks/bar')
+        .reply(204);
+
+      const result = await slyk.webhook.delete('bar');
+
+      expect(result).toEqual(true);
+    });
+  });
+
+  describe('get', () => {
+    it('should call api `/webhooks/bar` endpoint with method `get` and return an instance of `Webhook` model with the given `data`', async () => {
+      nock(host, { reqheaders: { apikey } })
+        .get('/webhooks/bar')
+        .query({ include: 'webhookEvents' })
+        .reply(200, {
+          data: {
+            description: 'bar',
+            enabled: true,
+            webhookEvents: [{ id: 'foo', status: 'completed' }]
+          }
+        });
+
+      const result = await slyk.webhook.get('bar', { include: 'webhookEvents' });
+
+      expect(result).toEqual({
+        description: 'bar',
+        enabled: true,
+        webhookEvents: [{ id: 'foo', status: 'completed' }]
+      });
+    });
+  });
+
+  describe('list', () => {
+    it('should call api `/webhooks` endpoint with method `get` and return an array of instances of `Webhook` model in the `results` attribute and the `total`', async () => {
+      nock(host, { reqheaders: { apikey } })
+        .get('/webhooks')
+        .query({ page: { number: 3, size: 2 } })
+        .reply(200, {
+          data: [
+            { description: 'bar', enabled: true },
+            { description: 'foo', enabled: true }
+          ],
+          total: 2
+        });
+
+      const { results, total } = await slyk.webhook.list({ page: { number: 3, size: 2 } });
+
+      expect(results).toEqual([
+        { description: 'bar', enabled: true },
+        { description: 'foo', enabled: true }
+      ]);
+
+      expect(total).toEqual(2);
+    });
+  });
+
+  describe('patch', () => {
+    it('should call api `/webhooks/bar` endpoint with method `patch` and return an instance of `Webhook` model with the given `data`', async () => {
+      nock(host, { reqheaders: { apikey } })
+        .patch('/webhooks/bar', { enabled: false })
+        .reply(200, { data: { description: 'bar', enabled: false } });
+
+      const result = await slyk.webhook.patch('bar', { enabled: false });
+
+      expect(result).toEqual({ description: 'bar', enabled: false });
+    });
+  });
+});

--- a/test/src/webhook/models/webhook-model.test.js
+++ b/test/src/webhook/models/webhook-model.test.js
@@ -1,0 +1,53 @@
+
+/**
+ * Module dependencies.
+ */
+
+import nock from 'nock';
+import sdk from '';
+
+/**
+ * Test `WebhookModel`.
+ */
+
+describe('WebhookModel', () => {
+  const apikey = 'xyzzy';
+  const host = 'http://foobar:3000';
+  const slyk = sdk({ apikey, host });
+
+  describe('delete', () => {
+    it('should return `true` after deleting the `webhook` instance', async () => {
+      nock(host, { reqheaders: { apikey } })
+        .get('/webhooks/bar')
+        .reply(200, { data: { enabled: true, id: 'bar' } });
+
+      const webhook = await slyk.webhook.get('bar');
+
+      nock(host, { reqheaders: { apikey } })
+        .delete('/webhooks/bar')
+        .reply(204);
+
+      const response = await webhook.delete();
+
+      expect(response).toEqual(true);
+    });
+  });
+
+  describe('patch', () => {
+    it('should return the patched `webhook`', async () => {
+      nock(host, { reqheaders: { apikey } })
+        .get('/webhooks/bar')
+        .reply(200, { data: { enabled: true, id: 'bar' } });
+
+      const webhook = await slyk.webhook.get('bar');
+
+      nock(host, { reqheaders: { apikey } })
+        .patch('/webhooks/bar', { enabled: false })
+        .reply(200, { data: { enabled: false, id: 'bar' } });
+
+      const patchedWebhook = await webhook.patch({ enabled: false });
+
+      expect(patchedWebhook).toEqual({ enabled: false, id: 'bar' });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds the Webhook module which contains the following methods:
* `create`;
* `delete`;
* `get`;
* `list`;
* `patch`.