### PR TITLE
Fix payloads containing property names with dots

### DIFF
--- a/src/core/util/clean-request-data.js
+++ b/src/core/util/clean-request-data.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-import { reduce, set } from 'lodash';
+import { reduce } from 'lodash';
 
 /**
  * Export `cleanRequestData`.
@@ -15,6 +15,6 @@ export default (data, endpoint) => {
       return result;
     }
 
-    return set(result, key, value);
+    return { ...result, [key]: value };
   }, {});
 };


### PR DESCRIPTION
This PR fixes `cleanRequestData` by setting the result using spread instead of `lodash.set` since a `.` (dot) has sematic meaning for `lodash.set` - it is treated as a path instead of a literal string.